### PR TITLE
READMEにロゴ画像を表示するように

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/codeforosaka/covid19/workflows/production%20deploy/badge.svg)
 
-![大阪府 新型コロナウイルス感染症対策サイト](https://covid19-osaka.info/ogp.png)
+[![大阪府 新型コロナウイルス感染症対策サイト](https://covid19-osaka.info/ogp.png)](https://covid19-osaka.info/)
 
 ## 貢献の仕方
 Issues にあるいろいろな修正にご協力いただけると嬉しいです。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/codeforosaka/covid19/workflows/production%20deploy/badge.svg)
 
-![大阪府 新型コロナウイルス感染症対策サイト](https://covid19-osaka.info/)
+![大阪府 新型コロナウイルス感染症対策サイト](https://covid19-osaka.info/ogp.png)
 
 ## 貢献の仕方
 Issues にあるいろいろな修正にご協力いただけると嬉しいです。


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
READMEの「大阪府 新型コロナウイルス感染症対策サイト」で画像のリンク切れが発生しており本家のリポジトリのようにロゴを表示する想定だったのかな？と思いましたのでOGP画像を表示するように変更いたしました。

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/54523771/77427276-72f33280-6e19-11ea-9f4b-33a55486b267.png)
