### PR TITLE
i18nの型宣言ファイルを読み込むように対応

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -222,18 +222,20 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
 
-export default {
+export default Vue.extend({
   components: {
     TextCard
   },
-  head() {
+  head(): MetaInfo {
     return {
       title: this.$t('当サイトについて') as string
     }
   }
-}
+})
 </script>
 
 <style lang="scss">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     },
     "types": [
       "@types/node",
-      "@nuxt/types"
+      "@nuxt/types",
+      "nuxt-i18n"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- 多言語で表示できるようにしたい #110 

## ⛏ 変更内容 / Details of Changes

- i18nの型宣言ファイルが読み込まれていなかったので、tsconfigのtypesに`nuxt-i18n`を追記
- `lang="ts"`内で`Vue.extend`していない箇所を修正