### PR TITLE
「陽性者の属性」のソートにおける「未就学児」の位置を修正

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -78,6 +78,8 @@
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 
+const excludeAges = ['就学児', '未就学児']
+
 export default {
   components: { DataView, DataViewBasicInfoPanel },
   props: {
@@ -110,18 +112,44 @@ export default {
   },
   methods: {
     customSort(items, index, isDescending) {
-      // if (index[0] === '年代') {
-      // }
       if (isDescending[0] === undefined) return items
-      console.log(items, index, isDescending)
+      if (index[0] === '年代') {
+        return this.createSortAgeData(items, index[0], isDescending[0])
+      } else {
+        items.sort((a, b) => {
+          if (b[index[0]] < a[index[0]]) {
+            return isDescending[0] ? -1 : 1
+          } else {
+            return isDescending[0] ? 1 : -1
+          }
+        })
+      }
+      return items
+    },
+    createSortAgeData(items, index, isDescending) {
+      const excludeItems = []
       items.sort((a, b) => {
-        if (b[index[0]] < a[index[0]]) {
-          return isDescending[0] ? -1 : 1
+        if (b[index] < a[index]) {
+          return -1
         } else {
-          return isDescending[0] ? 1 : -1
+          return 1
         }
       })
-      return items
+      const filterItems = items.filter(item => {
+        if (excludeAges.includes(item[index])) {
+          excludeItems.push(item)
+          return false
+        } else {
+          return true
+        }
+      })
+      excludeItems.forEach(item => {
+        filterItems.push(item)
+      })
+      if (isDescending) {
+        filterItems.reverse()
+      }
+      return filterItems
     }
   }
 }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -12,6 +12,7 @@
       :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"
+      :custom-sort="customSort"
     />
     <div class="note">
       ※退院とは新型コロナウイルス感染症が治癒した者<br />
@@ -105,6 +106,22 @@ export default {
       type: String,
       required: false,
       default: ''
+    }
+  },
+  methods: {
+    customSort(items, index, isDescending) {
+      // if (index[0] === '年代') {
+      // }
+      if (isDescending[0] === undefined) return items
+      console.log(items, index, isDescending)
+      items.sort((a, b) => {
+        if (b[index[0]] < a[index[0]]) {
+          return isDescending[0] ? -1 : 1
+        } else {
+          return isDescending[0] ? 1 : -1
+        }
+      })
+      return items
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #167 

## ⛏ 変更内容 / Details of Changes

- 年代のソートをすると文字列の比較で「未就学児」「就学児」の位置がおかしかったので、`v-data-table`の`custom-sort`を使って想定の並び順にする。
