### PR TITLE
PR #172 就学児と未就学児の順序が逆になっていたので修正

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -130,9 +130,9 @@ export default {
       const excludeItems = []
       items.sort((a, b) => {
         if (b[index] < a[index]) {
-          return -1
-        } else {
           return 1
+        } else {
+          return -1
         }
       })
       const filterItems = items.filter(item => {
@@ -143,8 +143,8 @@ export default {
           return true
         }
       })
-      excludeItems.reverse().forEach(item => {
-        filterItems.push(item)
+      excludeItems.forEach(item => {
+        filterItems.unshift(item)
       })
       if (isDescending) {
         filterItems.reverse()

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -143,7 +143,7 @@ export default {
           return true
         }
       })
-      excludeItems.forEach(item => {
+      excludeItems.reverse().forEach(item => {
         filterItems.push(item)
       })
       if (isDescending) {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #167 
- PR #172 

## ⛏ 変更内容 / Details of Changes

- 「就学児」と「未就学児」の順序が逆になっていたので修正

## 📸 スクリーンショット / Screenshots

- 昇順並び替え時

![スクリーンショット 2020-04-02 19 22 23](https://user-images.githubusercontent.com/32923565/78238233-4d4fe280-7517-11ea-8dbd-9db011d25282.png)

- 降順並び替え時

![スクリーンショット 2020-04-02 19 31 45](https://user-images.githubusercontent.com/32923565/78239387-9bb1b100-7518-11ea-83d0-03f912b87ffe.png)

