### PR TITLE
お知らせの日付非表示に対応

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -15,6 +15,7 @@
           rel="noopener"
         >
           <time
+            v-if="item.date"
             class="WhatsNew-list-item-anchor-time px-2"
             :datetime="formattedDate(item.date)"
           >

--- a/data/news.json
+++ b/data/news.json
@@ -1,7 +1,7 @@
 {
     "newsItems": [
         {
-            "date": "2020/04/13",
+            "date": "",
             "url": "http://www.pref.osaka.lg.jp/hodo/index.php?HST_TITLE1=%83R%83%8D%83i&SEARCH_NUM=10&searchFlg=%8C%9F%81@%8D%F5&site=fumin",
             "text": "新型コロナウイルス関連の報道発表について（外部サイト）"
         }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #254 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- news.json で date に空の文字列が入力されている場合は、日付を表示しない
- news.json の現在のお知らせから日付を除去

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/52195426/79465274-15c45880-8036-11ea-9174-0940b95ad753.png)
