### PR TITLE
「陽性者の属性」の表記など #267 一部対応

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -185,7 +185,7 @@ export default {
     for (const row of patientsTable.datasets) {
       row['居住地'] = this.$t(row['居住地'])
       row['性別'] = this.$t(row['性別'])
-      row['退院'] = this.$t(row['退院'])
+      row['退院・解除'] = this.$t(row['退院・解除'])
 
       if (otherAges.includes(row['年代'])) {
         row['年代'] = this.$t(row['年代'])

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -45,7 +45,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
-          :title="$t('陰性確認済（退院者累計）')"
+          :title="$t('退院・解除済累計')"
           :title-id="'number-of-treated'"
           :chart-id="'time-bar-chart-inspections'"
           :chart-data="treatedGraph"

--- a/tool/main.py
+++ b/tool/main.py
@@ -100,10 +100,6 @@ class DataJson:
             data["リリース日"] = release_date.isoformat() + ".000Z"
             data["曜日"] = self.patients_sheet.cell(row=i, column=2).value
             data["居住地"] = self.patients_sheet.cell(row=i, column=5).value
-            if self.patients_sheet.cell(row=i, column=5).value == "調査中":
-                data["居住地"] = data["居住地"]
-            elif self.patients_sheet.cell(row=i, column=5).value != "大阪府外":
-                data["居住地"] = "大阪府" + data["居住地"]
             data["年代"] = str(self.patients_sheet.cell(row=i, column=3).value) + (
                 "代" if isinstance(self.patients_sheet.cell(row=i, column=3).value, int) else ""
             )

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -6,7 +6,7 @@ const headers = [
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
   { text: '性別', value: '性別' },
-  { text: '退院', value: '退院', align: 'center' }
+  { text: '退院・解除', value: '退院・解除', align: 'center' }
 ]
 
 type DataType = {
@@ -25,7 +25,7 @@ type TableDataType = {
   居住地: DataType['居住地']
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
-  退院: DataType['退院']
+  '退院・解除': DataType['退院']
 }
 
 type TableDateType = {
@@ -45,7 +45,7 @@ export default (data: DataType[]) => {
       居住地: d['居住地'] ?? '不明',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明',
-      退院: d['退院']
+      '退院・解除': d['退院']
     }
     tableDate.datasets.push(TableRow)
   })


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- #267 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性者の属性」の項目名「退院」を「退院・解除」に変更 (中黒は素の状態ではオブジェクトのキーに使えないらしいので、キーが文字列だと明示している)
- 「陽性者の属性」の項目「居住地」で「大阪府〇〇市」の「大阪府」を付加しないように `tool/main.py` を修正 (結果的には Excel ファイルの入力をそのまま使うことになる)
- 「陰性確認済（退院者累計）」パネル標題を「退院・解除済累計」に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
