### PR TITLE
リンク不明率がNaNになる問題を修正

### DIFF
--- a/components/TimeStackedBarChart2.vue
+++ b/components/TimeStackedBarChart2.vue
@@ -93,8 +93,12 @@ export default {
         const lastRatio = this.formatDayBeforeRatio(
           lastArray[0] - lastlastArray[0]
         )
-        const lastPercent =
+        let lastPercent =
           Math.floor((lastNum / this.sum(lastArray)) * 100 * 10 ** 2) / 10 ** 2
+
+        if (isNaN(lastPercent)) {
+          lastPercent = 0
+        }
 
         return {
           lText: lastNum.toLocaleString(),


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #453

## ⛏ 変更内容 / Details of Changes
- 最新の感染経路不明者データが0人になっている時にリンク不明率がNaNになる問題を修正

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/54523771/83011508-f406ba00-a054-11ea-992c-573da63310d2.png)

