### PR TITLE
検査陽性者の状況のバーをグループ化

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -217,7 +217,13 @@ export default {
 $borderWidth: 2px;
 $itemGap: 0.25em;
 
-@mixin boxShadow($color) {
+$positiveColor: lighten($green-1, 50%);
+$currentPositiveColor: #e6e6e6;
+$deceasedColor: #ccc;
+$conductedColor: #333;
+
+// for .sub-container
+@mixin scBoxShadow($color) {
   box-shadow: $color 0px 2px 0px 0px inset;
 }
 
@@ -248,7 +254,7 @@ ul.sub-container {
     border: solid $green-1;
     border-width: 0 $borderWidth $borderWidth;
 
-    @include boxShadow(#fff);
+    @include scBoxShadow(#fff);
 
     position: absolute;
     top: -2px;
@@ -257,19 +263,19 @@ ul.sub-container {
   }
 
   &.is-positive::before {
-    background: lighten($green-1, 50%);
-    @include boxShadow(lighten($green-1, 50%));
+    background: $positiveColor;
+    @include scBoxShadow($positiveColor);
   }
 
   &.is-current-positive {
     &::before,
     .sub-container::before {
-      background: #e6e6e6;
-      @include boxShadow(#e6e6e6);
+      background: $currentPositiveColor;
+      @include scBoxShadow($currentPositiveColor);
     }
 
     .row {
-      background: #e6e6e6;
+      background: $currentPositiveColor;
     }
   }
 }
@@ -279,29 +285,29 @@ ul.sub-container {
   align-items: center;
   justify-content: space-between;
 
-  padding: 0.5em 0.75em;
+  padding: 0.5em 1em;
 
   font-weight: bold;
 
   border: solid 2px $green-1;
 
-  color: $green-1;
+  color: darken($green-1, 15%);
 
   &.is-positive {
-    background: lighten($green-1, 50%);
+    background: $positiveColor;
   }
 
   &.is-deceased {
-    background: #ccc;
+    background: $deceasedColor;
   }
 
   &.is-current-positive {
-    background: #e6e6e6;
+    background: $currentPositiveColor;
   }
 
   &.is-conducted {
-    border-color: #333;
-    color: #4d4d4d;
+    border-color: $conductedColor;
+    color: $conductedColor;
   }
 }
 
@@ -309,5 +315,7 @@ ul.sub-container {
   flex: none;
 
   margin-left: 1em;
+
+  letter-spacing: 0.075em;
 }
 </style>

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -32,21 +32,25 @@
         <span>{{ $t('陽性者数（累積）') }}</span>
         <span :class="$style.value">{{ 陽性物数 }}{{ $t('人') }}</span>
       </div>
-      <ul :class="$style.container">
+      <ul
+        :class="[$style.container, $style.subContainer, $style['is-positive']]"
+      >
         <li>
-          <div :class="[$style.row, $style['is-positive']]">
+          <div :class="$style.row">
             <span>{{ $t('現在陽性者数') }}</span>
             <span :class="$style.value">{{ 現在陽性者数 }}{{ $t('人') }}</span>
           </div>
-          <ul :class="$style.container">
+          <ul
+            :class="[$style.container, $style.subContainer, $style['is-gray']]"
+          >
             <li>
-              <div :class="[$style.row, $style['is-gray']]">
+              <div :class="[$style.row]">
                 <span v-text="$t('入院')" />
                 <span :class="$style.value">{{ 入院中 }}{{ $t('人') }}</span>
               </div>
-              <ul :class="$style.container">
+              <ul :class="[$style.container, $style.subContainer]">
                 <li>
-                  <div :class="[$style.row, $style['is-gray']]">
+                  <div :class="$style.row">
                     <span>{{ $t('重症') }}</span>
                     <span :class="$style.value">{{ 重症 }}{{ $t('人') }}</span>
                   </div>
@@ -196,37 +200,65 @@ export default {
 </script>
 
 <style lang="scss" module>
-$rowSidePadding: 1.5em;
-$rowNestPadding: 2em;
+$borderWidth: 2px;
+$itemGap: 0.25em;
+
+@mixin boxShadow($color) {
+  box-shadow: $color 0px 2px 0px 0px inset;
+}
 
 .container {
-  &,
-  ul {
-    padding-left: 0 !important;
-  }
+  padding: 0 !important;
 
   &,
   li {
     list-style: none;
   }
 
-  > * + *,
-  .container {
-    margin-top: 4px;
+  > li + li {
+    margin-top: $itemGap;
+  }
+}
+
+.subContainer {
+  padding: $itemGap 0 0 2.25em !important;
+  position: relative;
+
+  &::before {
+    content: '';
+
+    width: 2em;
+
+    border: solid $green-1;
+    border-width: 0 $borderWidth $borderWidth;
+
+    @include boxShadow(#fff);
+
+    position: absolute;
+    top: -2px;
+    left: 0;
+    bottom: 0;
   }
 
-  // ネスト用のスタイルを吐き出す
-  @for $i from 1 to 4 {
-    $selector: '.container';
-
-    @for $j from 1 to $i {
-      $selector: $selector + ' .container';
+  &.is-positive {
+    .row,
+    ::before {
+      background: lighten($green-1, 50%);
     }
 
-    $selector: $selector + ' .row';
+    ::before {
+      @include boxShadow(lighten($green-1, 50%));
+    }
+  }
 
-    #{$selector} {
-      padding-left: $rowNestPadding * $i + $rowSidePadding;
+  &.is-gray {
+    .row,
+    ::before {
+      background: lighten(#333, 50%);
+    }
+
+    ::before {
+      @include boxShadow(lighten(#333, 50%));
     }
   }
 }
@@ -236,7 +268,7 @@ $rowNestPadding: 2em;
   align-items: center;
   justify-content: space-between;
 
-  padding: 0.25em $rowSidePadding;
+  padding: 0.5em;
 
   font-weight: bold;
 
@@ -244,21 +276,8 @@ $rowNestPadding: 2em;
 
   color: $green-1;
 
-  &.is-black {
-    border-color: #333;
-    color: #4d4d4d;
-  }
-
   &.is-deceased {
-    background: rgba(#333, 30%);
-  }
-
-  &.is-positive {
-    background: rgba($green-1, 20%);
-  }
-
-  &.is-gray {
-    background: rgba(#333, 10%);
+    background: rgba(#333, 30%) !important;
   }
 }
 

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -28,7 +28,7 @@
       </div>
     </li>
     <li>
-      <div :class="$style.row">
+      <div :class="[$style.row, $style['is-positive']]">
         <span>{{ $t('陽性者数（累積）') }}</span>
         <span :class="$style.value">{{ 陽性物数 }}{{ $t('人') }}</span>
       </div>
@@ -36,7 +36,7 @@
         :class="[$style.container, $style.subContainer, $style['is-positive']]"
       >
         <li>
-          <div :class="$style.row">
+          <div :class="[$style.row, $style['is-gray']]">
             <span>{{ $t('現在陽性者数') }}</span>
             <span :class="$style.value">{{ 現在陽性者数 }}{{ $t('人') }}</span>
           </div>
@@ -44,13 +44,19 @@
             :class="[$style.container, $style.subContainer, $style['is-gray']]"
           >
             <li>
-              <div :class="[$style.row]">
+              <div :class="[$style.row, $style['is-gray']]">
                 <span v-text="$t('入院')" />
                 <span :class="$style.value">{{ 入院中 }}{{ $t('人') }}</span>
               </div>
-              <ul :class="[$style.container, $style.subContainer]">
+              <ul
+                :class="[
+                  $style.container,
+                  $style.subContainer,
+                  $style['is-gray']
+                ]"
+              >
                 <li>
-                  <div :class="$style.row">
+                  <div :class="[$style.row, $style['is-gray']]">
                     <span>{{ $t('重症') }}</span>
                     <span :class="$style.value">{{ 重症 }}{{ $t('人') }}</span>
                   </div>
@@ -94,7 +100,7 @@
           </div>
         </li>
         <li>
-          <div :class="$style.row">
+          <div :class="[$style.row, $style['is-white']]">
             <span>{{ $t('退院・解除済累計') }}</span>
             <span :class="$style.value">{{ 退院 }}{{ $t('人') }}</span>
           </div>
@@ -207,8 +213,8 @@ $itemGap: 0.25em;
   box-shadow: $color 0px 2px 0px 0px inset;
 }
 
-.container {
-  padding: 0 !important;
+ul.container {
+  padding: 0;
 
   &,
   li {
@@ -220,8 +226,8 @@ $itemGap: 0.25em;
   }
 }
 
-.subContainer {
-  padding: $itemGap 0 0 2.25em !important;
+ul.subContainer {
+  padding: $itemGap 0 0 2.25em;
   position: relative;
 
   &::before {
@@ -240,26 +246,14 @@ $itemGap: 0.25em;
     bottom: 0;
   }
 
-  &.is-positive {
-    .row,
-    ::before {
-      background: lighten($green-1, 50%);
-    }
-
-    ::before {
-      @include boxShadow(lighten($green-1, 50%));
-    }
+  &.is-positive::before {
+    background: lighten($green-1, 50%);
+    @include boxShadow(lighten($green-1, 50%));
   }
 
-  &.is-gray {
-    .row,
-    ::before {
-      background: lighten(#333, 50%);
-    }
-
-    ::before {
-      @include boxShadow(lighten(#333, 50%));
-    }
+  &.is-gray::before {
+    background: #e6e6e6;
+    @include boxShadow(#e6e6e6);
   }
 }
 
@@ -268,7 +262,7 @@ $itemGap: 0.25em;
   align-items: center;
   justify-content: space-between;
 
-  padding: 0.5em;
+  padding: 0.5em 0.75em;
 
   font-weight: bold;
 
@@ -276,8 +270,20 @@ $itemGap: 0.25em;
 
   color: $green-1;
 
+  &.is-positive {
+    background: lighten($green-1, 50%);
+  }
+
   &.is-deceased {
-    background: rgba(#333, 30%) !important;
+    background: #ccc;
+  }
+
+  &.is-white {
+    background: #fff;
+  }
+
+  &.is-gray {
+    background: #e6e6e6;
   }
 }
 

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -20,7 +20,7 @@
     "
   >
     <li>
-      <div :class="[$style.row, $style['is-black']]">
+      <div :class="[$style.row, $style['is-conducted']]">
         <span v-text="$t('検査実施件数')">)"></span>
         <span :class="$style.value"
           >{{ 検査実施人数 }}{{ $t('件.tested') }}</span
@@ -33,15 +33,23 @@
         <span :class="$style.value">{{ 陽性物数 }}{{ $t('人') }}</span>
       </div>
       <ul
-        :class="[$style.container, $style.subContainer, $style['is-positive']]"
+        :class="[
+          $style.container,
+          $style['sub-container'],
+          $style['is-positive']
+        ]"
       >
         <li>
-          <div :class="[$style.row, $style['is-gray']]">
+          <div :class="[$style.row, $style['is-current-positive']]">
             <span>{{ $t('現在陽性者数') }}</span>
             <span :class="$style.value">{{ 現在陽性者数 }}{{ $t('人') }}</span>
           </div>
           <ul
-            :class="[$style.container, $style.subContainer, $style['is-gray']]"
+            :class="[
+              $style.container,
+              $style['sub-container'],
+              $style['is-current-positive']
+            ]"
           >
             <li>
               <div :class="[$style.row, $style['is-gray']]">
@@ -51,7 +59,7 @@
               <ul
                 :class="[
                   $style.container,
-                  $style.subContainer,
+                  $style['sub-container'],
                   $style['is-gray']
                 ]"
               >
@@ -100,7 +108,7 @@
           </div>
         </li>
         <li>
-          <div :class="[$style.row, $style['is-white']]">
+          <div :class="$style.row">
             <span>{{ $t('退院・解除済累計') }}</span>
             <span :class="$style.value">{{ 退院 }}{{ $t('人') }}</span>
           </div>
@@ -216,6 +224,8 @@ $itemGap: 0.25em;
 ul.container {
   padding: 0;
 
+  letter-spacing: 0.05em;
+
   &,
   li {
     list-style: none;
@@ -226,7 +236,7 @@ ul.container {
   }
 }
 
-ul.subContainer {
+ul.sub-container {
   padding: $itemGap 0 0 2.25em;
   position: relative;
 
@@ -251,9 +261,16 @@ ul.subContainer {
     @include boxShadow(lighten($green-1, 50%));
   }
 
-  &.is-gray::before {
-    background: #e6e6e6;
-    @include boxShadow(#e6e6e6);
+  &.is-current-positive {
+    &::before,
+    .sub-container::before {
+      background: #e6e6e6;
+      @include boxShadow(#e6e6e6);
+    }
+
+    .row {
+      background: #e6e6e6;
+    }
   }
 }
 
@@ -278,12 +295,13 @@ ul.subContainer {
     background: #ccc;
   }
 
-  &.is-white {
-    background: #fff;
+  &.is-current-positive {
+    background: #e6e6e6;
   }
 
-  &.is-gray {
-    background: #e6e6e6;
+  &.is-conducted {
+    border-color: #333;
+    color: #4d4d4d;
   }
 }
 


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #463

## ⛏ 変更内容 / Details of Changes
- 検査陽性者の状況のバーをグループ化しました

CSSの調整をしたいと考えているので、いったんドラフトとして作成します。

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/54523771/84042690-5ad68c80-a9e0-11ea-8375-f4ca9b644dc9.png)

