### PR TITLE
IE 11でセリフ体が表示されてる問題の対応

### DIFF
--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -25,7 +25,6 @@
     &-summary {
       display: inline-block;
       color: $gray-2;
-      font-family: Hiragino Sans;
       font-style: normal;
       font-size: 30px;
       line-height: 30px;

--- a/components/NumberDisplay.vue
+++ b/components/NumberDisplay.vue
@@ -13,7 +13,6 @@
 
 <style lang="scss" scoped>
 .TheNumber {
-  font-family: Hiragino Sans;
   font-style: normal;
   font-weight: bold;
   font-size: 60px;
@@ -24,7 +23,6 @@
   color: $gray-2;
 }
 .TheUnit {
-  font-family: Hiragino Sans;
   font-style: normal;
   font-weight: bold;
   font-size: 40px;


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #645 

## ⛏ 変更内容 / Details of Changes
- font-familyを削除し、サンセリフ体が表示されるようにした

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/54523771/94912320-74956580-04e2-11eb-880e-7447ff582162.png)

