### PR TITLE
 [市区町村地図]地図の横に大阪府の市町村一覧を表示する

### DIFF
--- a/components/GraphicalMapCard.vue
+++ b/components/GraphicalMapCard.vue
@@ -256,6 +256,19 @@ function drawOsaka(vm) {
           })
       })
 
+      // 左側にデータ表示
+      let i = 0
+      for (const [key, value] of Object.entries(cityPatientsNumber)) {
+        map
+          .append('text')
+          .attr('x', 20)
+          .attr('y', function() {
+            return i++ * 13 + 20
+          })
+          .style('font-size', 12 + 'px')
+          .text(key + ': ' + value)
+      }
+
       // 地図表示済みに設定
       mapDrawn = true
     } else {
@@ -267,6 +280,20 @@ function drawOsaka(vm) {
           const cityName = getCity(d)
           return getColor(cityPatientsNumber[cityName])
         })
+
+      // 左側にデータ表示
+      let i = 0
+      d3.selectAll('text').remove()
+      for (const [key, value] of Object.entries(cityPatientsNumber)) {
+        map
+          .append('text')
+          .attr('x', 20)
+          .attr('y', function() {
+            return i++ * 13 + 20
+          })
+          .style('font-size', 12 + 'px')
+          .text(key + ': ' + value)
+      }
     }
 
     console.log('end drawOsaka()')

--- a/components/GraphicalMapCard.vue
+++ b/components/GraphicalMapCard.vue
@@ -255,22 +255,6 @@ function drawOsaka(vm) {
             tooltip.style('opacity', 0)
           })
       })
-
-      // 左側にデータ表示
-      let i = 0
-      for (const [key, value] of Object.entries(cityPatientsNumber)) {
-        map
-          .append('text')
-          .attr('x', 20)
-          .attr('y', function() {
-            return i++ * 13 + 20
-          })
-          .style('font-size', 12 + 'px')
-          .text(key + ': ' + value)
-      }
-
-      // 地図表示済みに設定
-      mapDrawn = true
     } else {
       // ２回目以降は更新のみ
       map
@@ -280,22 +264,24 @@ function drawOsaka(vm) {
           const cityName = getCity(d)
           return getColor(cityPatientsNumber[cityName])
         })
-
-      // 左側にデータ表示
-      let i = 0
-      d3.selectAll('text').remove()
-      for (const [key, value] of Object.entries(cityPatientsNumber)) {
-        map
-          .append('text')
-          .attr('x', 20)
-          .attr('y', function() {
-            return i++ * 13 + 20
-          })
-          .style('font-size', 12 + 'px')
-          .text(key + ': ' + value)
-      }
     }
 
+    // 左側にデータ表示
+    let i = 0
+    map.selectAll('text').remove()
+    for (const [key, value] of Object.entries(cityPatientsNumber)) {
+      map
+        .append('text')
+        .attr('x', 20)
+        .attr('y', function() {
+          return i++ * 13 + 20
+        })
+        .style('font-size', 12 + 'px')
+        .text(key + ': ' + value)
+    }
+
+    // 地図表示済みに設定
+    mapDrawn = true
     console.log('end drawOsaka()')
   })
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues
[市区町村地図]地図の横に大阪府の市町村一覧を表示する #684

- close #684

## ⛏ 変更内容 / Details of Changes
- 地図の横に大阪府の市町村一覧を表示
- リファクタリング

## 📸 スクリーンショット / Screenshots
<img width="568" alt="スクリーンショット 2020-11-16 16 30 41" src="https://user-images.githubusercontent.com/18328371/99224232-474e0e00-2829-11eb-9e88-a077807a6951.png">

