### PR TITLE
[市区町村地図]表示期間の最小範囲が14日固定なのを動的に変更できるようにする

### DIFF
--- a/components/DateSelectSlider.vue
+++ b/components/DateSelectSlider.vue
@@ -34,6 +34,11 @@ export default {
       type: Number,
       required: true,
       default: 1
+    },
+    minRange: {
+      type: Number,
+      required: true,
+      default: 1
     }
   },
   data() {
@@ -41,8 +46,8 @@ export default {
       sliderValue: this.value,
       rules: [
         v =>
-          Math.abs(v[0] - v[1]) > 14 ||
-          this.$t('表示期間の最小範囲は１４日間です')
+          Math.abs(v[0] - v[1]) >= this.minRange ||
+          this.$t('表示期間の最小範囲は' + this.minRange + '日間です')
       ]
     }
   },
@@ -51,7 +56,7 @@ export default {
       this.sliderValue = [0, this.sliderMax]
     },
     sliderValue(newValue, oldValue) {
-      if (Math.abs(newValue[0] - newValue[1]) <= 14) {
+      if (Math.abs(newValue[0] - newValue[1]) <= this.minRange) {
         this.sliderValue = oldValue
       } else {
         this.$emit('sliderInput', newValue)

--- a/components/GraphicalMapCard.vue
+++ b/components/GraphicalMapCard.vue
@@ -32,6 +32,7 @@
       :chart-data="chartData"
       :value="[0, sliderMax]"
       :slider-max="sliderMax"
+      :min-range="0"
       @sliderInput="sliderUpdate"
     />
     <p :class="$style.note">
@@ -341,32 +342,26 @@ $infected-level6: red;
   display: inline-block;
   margin: 0 0.5rem 0 0;
 }
-// 1-5
 .infected-level1 {
   fill: $infected-level1 !important;
   background-color: $infected-level1;
 }
-// 6-10
 .infected-level2 {
   fill: $infected-level2 !important;
   background-color: $infected-level2;
 }
-// 10-15
 .infected-level3 {
   fill: $infected-level3 !important;
   background-color: $infected-level3;
 }
-// 15-20
 .infected-level4 {
   fill: $infected-level4 !important;
   background-color: $infected-level4;
 }
-// 21-30
 .infected-level5 {
   fill: $infected-level5 !important;
   background-color: $infected-level5;
 }
-// 31-
 .infected-level6 {
   fill: $infected-level6 !important;
   background-color: $infected-level6;


### PR DESCRIPTION
## 📝 関連issue / Related Issues
[市区町村地図]表示期間の最小範囲が14日固定なのを動的に変更できるようにする #699

- close #699

## ⛏ 変更内容 / Details of Changes
- 表示期間の最小範囲が14日固定なのを動的に変更できるようにする。マップからは1日にする。

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-11-16 21 05 57](https://user-images.githubusercontent.com/18328371/99250773-9149ea80-284f-11eb-908f-4b553e0f9335.png)

