### PR TITLE
比率グラフ右縦軸の値を100%超えて表示できるようにする

### DIFF
--- a/components/RateChart.vue
+++ b/components/RateChart.vue
@@ -450,7 +450,7 @@ export default {
       return Math.max(...this.chartData.denomList)
     },
     scaledTicksYAxisMaxRight() {
-      return 100
+      return Math.max(100, Math.max(...this.chartData.rateList))
     }
   },
   created() {


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#750

## ⛏ 変更内容 / Details of Changes
- 右縦軸の最大値を、表示データから計算するように変更

## 📸 スクリーンショット / Screenshots

- Issueにて指摘されたグラフの表示(pullreq適用後)
![image](https://user-images.githubusercontent.com/13712028/117571075-f5b37b80-b107-11eb-94cc-e123ab463a8d.png)
